### PR TITLE
更新广点通接入权限配置

### DIFF
--- a/docs/YumiMediationSDK Unity - Mediation List(en) .md
+++ b/docs/YumiMediationSDK Unity - Mediation List(en) .md
@@ -261,6 +261,8 @@ Before you use mediation , make sure you has integrated YumiMobiSDK by 《YumiMo
 
 **Permission：**
 ```xml
+<uses-permission android:name="android.permission.READ_PHONE_STATE" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />  
 <uses-permission android:name="android.permission.ACCESS_COARSE_UPDATES"/>
 ```

--- a/docs/YumiMediationSDK Unity - Mediation List(zh-cn) .md
+++ b/docs/YumiMediationSDK Unity - Mediation List(zh-cn) .md
@@ -260,6 +260,8 @@
 
 **额外权限：**
 ```xml
+<uses-permission android:name="android.permission.READ_PHONE_STATE" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />  
 <uses-permission android:name="android.permission.ACCESS_COARSE_UPDATES"/>
 ```


### PR DESCRIPTION
广点通广告需要添加获取手机状态权限和写入权限，如果没有的话会出现获取不到广告的现象